### PR TITLE
Multiple methods in limit_except_fix directive

### DIFF
--- a/include/LimitExceptDirective.hpp
+++ b/include/LimitExceptDirective.hpp
@@ -7,7 +7,7 @@
 
 struct LimitExceptDirective
 {
-	Method method;
+	std::vector<Method> methods;
 	std::string allow;
 	std::string deny;
 };

--- a/include/ParsingHelper.hpp
+++ b/include/ParsingHelper.hpp
@@ -50,8 +50,8 @@ private:
 	static void parseErrorPage(std::map<int, std::string> &errorPageMap, std::string &info);
 	static void parseLocation(ConfigBlock &serverBlock, ServerConfig &serverConfig);
 	static std::vector<LimitExceptDirective> parseLimitExcepts(ConfigBlock &locationBlock);
-
-	static Method parseMethod(std::string method);
+	static std::vector<Method> parseMethods(std::vector<std::string> &methods);
+	static Method strToMethod(std::string method);
 };
 
 #endif

--- a/nginx.conf
+++ b/nginx.conf
@@ -42,7 +42,7 @@ http{
 
         location /python_cgi/ {
 	
-            limit_except GET {
+            limit_except GET POST {
                 deny all;
             }
             root /cgi_location;

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -117,7 +117,13 @@ void ServerManager::printLocations(std::vector<Location> locations) const
 		std::cout << "	Limit except: " << std::endl;
 		for (std::vector<LimitExceptDirective>::iterator led = it->limitExcepts.begin(); led != it->limitExcepts.end(); led++)
 		{
-			std::cout << "	-Method: " << ParsingHelper::methodToStr(led->method) << " Allow: " << led->allow << " Deny: " << led->deny << std::endl;
+			std::cout << "	-Mehods: ";
+			for (std::vector<Method>::iterator method = led->methods.begin(); method != led->methods.end(); method++)
+			{
+				std::cout << ParsingHelper::methodToStr(*method) << " ";
+			}
+
+			std::cout << " Allow: " << led->allow << " Deny: " << led->deny << std::endl;
 		}
 
 		std::cout << std::endl;

--- a/src/parsing_helper/ParsingHelper.cpp
+++ b/src/parsing_helper/ParsingHelper.cpp
@@ -163,7 +163,7 @@ std::vector<std::string> ParsingHelper::split(const std::string &str, char delim
 /// @brief Converts a string to the corresponding method.
 /// @param method Method as a string to convert.
 /// @return The string as a 'Method'.
-Method ParsingHelper::parseMethod(std::string method)
+Method ParsingHelper::strToMethod(std::string method)
 {
 	if (method == "GET")
 	{
@@ -293,16 +293,16 @@ std::vector<LimitExceptDirective> ParsingHelper::parseLimitExcepts(ConfigBlock &
 
 		if (contextInfo[0] == "limit_except")
 		{
-			if (contextInfo.size() != 2 || parseMethod(contextInfo[1]) == Method::NONE)
+			if (contextInfo.size() < 2)
 			{
-				Logger::log(ERROR, "limit_except must contain one method.");
-				throw std::invalid_argument("Error: limit_except must contain one method.");
+				Logger::log(ERROR, "limit_except must contain at least one method.");
+				throw std::invalid_argument("Error: limit_except must contain at least one method.");
 			}
 
 			for (std::vector<ConfigBlock>::iterator limitExceptBlock = it->second.begin(); limitExceptBlock != it->second.end(); limitExceptBlock++)
 			{
 				LimitExceptDirective limitExcept;
-				limitExcept.method = parseMethod(contextInfo[1]);
+				limitExcept.methods = parseMethods(contextInfo);
 
 				std::map<std::string, std::vector<std::string>>::iterator allowFinder = limitExceptBlock->getDirectives().find("allow");
 				limitExcept.allow = allowFinder != limitExceptBlock->getDirectives().end() ? allowFinder->second[0] : "";
@@ -316,6 +316,28 @@ std::vector<LimitExceptDirective> ParsingHelper::parseLimitExcepts(ConfigBlock &
 	}
 
 	return limitExcepts;
+}
+
+/// @brief Parses the methods from the limit_except directive.
+/// @param methods Vector of strings containing the methods.
+/// @return A vector of Method.
+/// @throw std::invalid_argument if any of the methods is not valid.
+std::vector<Method> ParsingHelper::parseMethods(std::vector<std::string> &methods)
+{
+	std::vector<Method> parsedMethods;
+
+	for (std::vector<std::string>::iterator it = methods.begin() + 1; it != methods.end(); it++)
+	{
+		Method method = strToMethod(*it);
+		if (method == Method::NONE)
+		{
+			Logger::log(ERROR, "Invalid method in limit_except directive.");
+			throw std::invalid_argument("Error: Invalid method in limit_except directive.");
+		}
+		parsedMethods.push_back(method);
+	}
+
+	return parsedMethods;
 }
 
 /// @brief Parses, validates and adds the directives to the given ServerConfig.


### PR DESCRIPTION
I was restricting  only one method in the directive, but it can have multiple

Example:

```
limit_except GET POST {
                deny all;
            }
```
