### PR TITLE
fix autoindex

### DIFF
--- a/config_files/default.conf
+++ b/config_files/default.conf
@@ -61,9 +61,6 @@ http{
         error_page 404 /404.html;
         error_page 500 502 503 504 /50x.html;
 
-        # Index files
-        index index.html index.htm;
-
         autoindex on;
 
         client_max_body_size 100;

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -256,8 +256,8 @@ void Response::handleGetRequest()
 	{
 		return handleResponseError(405);
 	}
-
-	std::filesystem::path relativeToRootPath = std::filesystem::relative(_request.getUri(), _root);
+	
+	std::filesystem::path relativeToRootPath = _request.getUri() != "/" ? std::filesystem::relative(_request.getUri(), _root) : "";
 	std::string path = _root + "/" + relativeToRootPath.string();
 
 	if (std::filesystem::is_regular_file(getFullPath(path)))
@@ -276,7 +276,7 @@ void Response::handleGetRequest()
 		}
 		if (_autoIndex)
 		{
-			handleAutoIndex(_request.getUri());
+			handleAutoIndex(path);
 		}
 		else
 		{

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -257,9 +257,12 @@ void Response::handleGetRequest()
 		return handleResponseError(405);
 	}
 
-	if (isFile(_request.getUri()))
+	std::filesystem::path relativeToRootPath = std::filesystem::relative(_request.getUri(), _root);
+	std::string path = _root + "/" + relativeToRootPath.string();
+
+	if (std::filesystem::is_regular_file(getFullPath(path)))
 	{
-		handleFileServing(_root + _request.getUri());
+		handleFileServing(path);
 	}
 	else
 	{
@@ -337,10 +340,24 @@ void Response::handleAutoIndex(const std::string &dirPath)
 	std::string fullPath = std::filesystem::current_path().c_str() + dirPath;
 	try
 	{
-		for (const auto &entry : std::filesystem::directory_iterator(fullPath))
+		for (std::filesystem::directory_iterator it(fullPath); it != std::filesystem::directory_iterator(); ++it)
 		{
-			std::string name = entry.path().filename().string();
-			body += "  <li><a href=\"" + name + "\">" + name + "</a></li>\n";
+			std::filesystem::path entryPath = it->path();
+			std::string name = entryPath.filename().string();
+
+			if (std::filesystem::is_directory(entryPath))
+			{
+				name += "/";
+			}
+
+			std::string basePath = dirPath;
+			if (!basePath.empty() && basePath.back() != '/')
+			{
+				basePath += '/';
+			}
+
+			std::string href = basePath + name;
+			body += "  <li><a href=\"" + href + "\">" + name + "</a></li>\n";
 		}
 	}
 	catch (const std::filesystem::filesystem_error &e)


### PR DESCRIPTION
Now autoindex is working. There were some issues with the path.

To test it, make sure to remove the index directive from the configuration file. Otherwise it will be redirect it to it.

Then access a folder such as "html", you'll see the list of files and folders inside. You can also access another folder and its files.