### PR TITLE
added 405 for wrong method

### DIFF
--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -125,6 +125,10 @@ void Response::handleRequest()
 	{
 		handleDeleteRequest();
 	}
+    else if (_request.getMethod() == Method::NONE)
+    {
+        handleResponseError(405);
+    }
 	else
 	{
 		handleResponseError(400);


### PR DESCRIPTION
added a fix for https://github.com/julicaro31/Webserv/issues/53
An extra check to see if there is a valid method, and it returns 405 when a nonvalid method is found