### PR TITLE
Improve ServerManager

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -59,7 +59,27 @@
         "thread": "cpp",
         "cinttypes": "cpp",
         "typeinfo": "cpp",
-        "semaphore": "cpp"
+        "semaphore": "cpp",
+        "__bit_reference": "cpp",
+        "__hash_table": "cpp",
+        "__locale": "cpp",
+        "__node_handle": "cpp",
+        "__split_buffer": "cpp",
+        "__tree": "cpp",
+        "__verbose_abort": "cpp",
+        "bitset": "cpp",
+        "execution": "cpp",
+        "iomanip": "cpp",
+        "ios": "cpp",
+        "locale": "cpp",
+        "mutex": "cpp",
+        "print": "cpp",
+        "queue": "cpp",
+        "stack": "cpp",
+        "variant": "cpp"
+    },
+    "[cpp]": {
+        "editor.defaultFormatter": "ms-vscode.cpptools"
     }
 }
 /*

--- a/config_files/default.conf
+++ b/config_files/default.conf
@@ -17,7 +17,7 @@ http{
 
         autoindex on;
 
-        client_max_body_size 100;
+        client_max_body_size 10000000;
 
         # Redirection (301, 302, etc.)
         location /old-path/ {
@@ -30,7 +30,7 @@ http{
 
             autoindex on;
             
-            client_max_body_size 50;
+            client_max_body_size 10000000;
 
             error_page 404 /error_pages/404.html;
             error_page 405 /error_pages/405.html;

--- a/config_files/default.conf
+++ b/config_files/default.conf
@@ -17,7 +17,7 @@ http{
 
         autoindex on;
 
-        client_max_body_size 10000000;
+        client_max_body_size 20000000;
 
         # Redirection (301, 302, etc.)
         location /old-path/ {
@@ -30,7 +30,7 @@ http{
 
             autoindex on;
             
-            client_max_body_size 10000000;
+            client_max_body_size 20000000;
 
             error_page 404 /error_pages/404.html;
             error_page 405 /error_pages/405.html;

--- a/config_files/default.conf
+++ b/config_files/default.conf
@@ -75,7 +75,7 @@ http{
 
             autoindex on;
 
-            client_max_body_size 50;
+            client_max_body_size 10000000;
 
             error_page 404 /error_pages/404.html;
             error_page 405 /error_pages/405.html;

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -16,9 +16,11 @@
 #include <fcntl.h>
 #include "Logger.hpp"
 #include "Location.hpp"
+#include <arpa/inet.h>
+#include <netdb.h>
 
-#define MAX_CONNECTION 10
-// If MAX_CONNECTION	 is exceeded, new connections wait in a queue (until accept() is called).
+
+
 
 class Server
 {

--- a/include/ServerManager.hpp
+++ b/include/ServerManager.hpp
@@ -12,8 +12,9 @@
 #include "ParsingHelper.hpp"
 #include <signal.h>
 
-#define MAX_CONNECTION 10 // is exceeded, new connections wait in a queue (until accept() is called).
 #define CLIENT_TIMEOUT 15 // disconnect clients that have been inactive, in seconds
+#define ReadChunkSize 4096
+#define WriteChunkSize 4096
 
 class ServerManager
 {
@@ -22,6 +23,9 @@ private:
 	std::vector<pollfd> _pollFDs;
 	std::map<int, Server *> _clientToServer;
 	std::map<int, time_t> _clientActivity;
+	std::map<int, std::string> _clientResponses;
+	std::map<int, std::string> _clientBuffers;
+
 
 	static void handleSigint(int sig);
 
@@ -48,6 +52,9 @@ public:
 	void handleClientRequest(int clientFD);
 	void removeClient(int clientFD);
 	void checkTimeouts();
+	void enablePollout(int clientFD);
+	void disablePollout(int clientFD);
+	bool isRequestComplete(const std::string &buffer);
 
 	void closeFDs();
 };

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -145,6 +145,16 @@ bool Server::setupSocket()
 		Logger::log(ERROR, "[Server] Socket creation failed");
 		return false;
 	}
+
+	int opt = 1;
+	if (setsockopt(_socketFD, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1)
+	{
+		perror("[Server] Failed to setsocketopt");
+		Logger::log(ERROR, "[Server] Failed to setsocketopt");
+		close(_socketFD);
+		return false;
+	}
+
 	if (setNonBlocking(_socketFD) == -1)
 	{
 		perror("[Server] Failed to set socket to non-blocking");
@@ -156,7 +166,7 @@ bool Server::setupSocket()
 	struct sockaddr_in _serverAddr;
 	memset(&_serverAddr, 0, sizeof(_serverAddr));
 	_serverAddr.sin_family = AF_INET;
-	_serverAddr.sin_addr.s_addr = INADDR_ANY;
+	_serverAddr.sin_addr.s_addr = inet_addr(_host.c_str());
 	_serverAddr.sin_port = htons(_port);
 
 	if (bind(_socketFD, (struct sockaddr *)&_serverAddr, sizeof(_serverAddr)) < 0)
@@ -166,7 +176,8 @@ bool Server::setupSocket()
 		close(_socketFD);
 		return false;
 	}
-	if (listen(_socketFD, MAX_CONNECTION) < 0)
+	// The exact value of SOMAXCONN is determined by the system and may vary between Mac and Linux.
+	if (listen(_socketFD, SOMAXCONN) < 0)
 	{
 		perror("[Server] Listen failed");
 		Logger::log(ERROR, "[Server] Listen failed");

--- a/src/ServerManager.cpp
+++ b/src/ServerManager.cpp
@@ -165,8 +165,7 @@ void ServerManager::runPoll()
 		signal(SIGINT, handleSigint);
 
 		checkTimeouts();
-		// Call poll() with a timeout of 500 milliseconds
-		int ready = poll(_pollFDs.data(), _pollFDs.size(), 500);
+		int ready = poll(_pollFDs.data(), _pollFDs.size(), -1);
 		if (ready < 0)
 		{
 			if (g_terminate)
@@ -194,6 +193,35 @@ void ServerManager::runPoll()
 				{
 					// If it's a client socket, read data
 					handleClientRequest(_pollFDs[i].fd);
+				}
+			}
+			if (_pollFDs[i].revents & POLLOUT)
+			{
+				int clientFD = _pollFDs[i].fd;
+				// Check if we have a response to this client to send
+				if (_clientResponses.find(clientFD) != _clientResponses.end())
+				{
+					std::string &response = _clientResponses[clientFD];
+					size_t responseBufferSize = WriteChunkSize;
+					Logger::log(INFO, "[ServerManager] Sending response to client FD " + std::to_string(clientFD) + " ResMsg: \n" + response);
+
+					ssize_t sBytes = send(clientFD, response.c_str(), std::min(responseBufferSize, response.size()), 0);
+					if (sBytes > 0)
+					{
+						response.erase(0, sBytes);
+					}
+					else if (response.empty())
+					{
+						disablePollout(clientFD);
+						_clientResponses.erase(clientFD);
+					}
+					else
+					{
+						perror("Failed to send response to client");
+						Logger::log(ERROR, "[ServerManager] Failed to send response to client");
+						_clientResponses.erase(clientFD);
+						removeClient(clientFD);
+					}
 				}
 			}
 			if (_pollFDs[i].revents & POLLHUP && !(_pollFDs[i].revents & POLLIN))
@@ -228,7 +256,8 @@ void ServerManager::acceptNewClient(int serverFD)
 	// Add new client socket to poll list, and map client FD to server
 	pollfd pfd;
 	pfd.fd = newClientFD;
-	pfd.events = POLLIN | POLLOUT;
+	// Set the events to POLLIN for reading only, we will set POLLOUT when we have a response to send
+	pfd.events = POLLIN;
 	_pollFDs.push_back(pfd);
 	_clientToServer[newClientFD] = getServerByFileDescriptor(serverFD);
 	_clientActivity[newClientFD] = time(NULL); // save client activity time
@@ -236,60 +265,94 @@ void ServerManager::acceptNewClient(int serverFD)
 
 void ServerManager::handleClientRequest(int clientFD)
 {
-	char buffer[1024];
-	int r = read(clientFD, buffer, sizeof(buffer) - 1);
+	char buffer[ReadChunkSize];
+	int rBytes = read(clientFD, buffer, sizeof(buffer) - 1);
 
-	if (r < 0)
+	if (rBytes < 0)
 	{
 		perror("Failed to read from client");
 		Logger::log(ERROR, "[ServerManager] Failed to read from client");
 		removeClient(clientFD);
 		return;
 	}
-	else if (r == 0)
+	else if (rBytes == 0)
 	{
 		removeClient(clientFD);
 		return;
 	}
-	buffer[r] = '\0';
-
-	_clientActivity[clientFD] = time(NULL); // Update activity timestamp
-
+	buffer[rBytes] = '\0';
 	Logger::log(INFO, "[ServerManager] Received from client FD " + std::to_string(clientFD) + '\n' + buffer);
+	_clientActivity[clientFD] = time(NULL);
+	_clientBuffers[clientFD].append(buffer, rBytes);
+	memset(buffer, 0, sizeof(buffer));
 
-	std::vector<Token> tokens;
-	try
+	// Check if the request is complete
+	if (isRequestComplete(_clientBuffers[clientFD]))
 	{
-		tokens = HttpParser::parseRequest(buffer);
-	}
-	catch (const char *exception)
-	{
-		std::cerr << "Error: " << exception << std::endl;
-	}
-	catch (...)
-	{
-		std::cerr << "Unknown error" << std::endl;
-	}
-
-	Request request = Request(tokens);
-	try
-	{
-		int serverFD = _clientToServer[clientFD]->getSocketFD();
-		Response response(request, *getServerByFileDescriptor(serverFD));
-		response.handleRequest();
-
-		if (send(clientFD, response.getMsg().c_str(), response.getMsg().length(), 0) < 0)
+		Logger::log(INFO, "[ServerManager] Request complete for client FD " + std::to_string(clientFD));
+		std::vector<Token> tokens;
+		try
 		{
-			perror("[ServerManager] Failed to send response");
-			Logger::log(ERROR, "[ServerManager] Failed to send response");
-			removeClient(clientFD);
+			tokens = HttpParser::parseRequest(_clientBuffers[clientFD]);
 		}
-		else
-			Logger::log(INFO, "[ServerManager] succesfuly send response");
+		catch (const char *exception)
+		{
+			std::cerr << "Error: " << exception << std::endl;
+		}
+		catch (...)
+		{
+			std::cerr << "Unknown error" << std::endl;
+		}
+
+		_clientBuffers[clientFD].clear();
+		Request request = Request(tokens);
+		try
+		{
+			int serverFD = _clientToServer[clientFD]->getSocketFD();
+			Response response(request, *getServerByFileDescriptor(serverFD));
+			response.handleRequest();
+
+			// store the response in the map
+			_clientResponses[clientFD] = response.getMsg();
+			Logger::log(INFO, "[ServerManager] Response for client FD " + std::to_string(clientFD) + " ResMsg: \n" + response.getMsg());
+
+			// Set the events to POLLOUT for sending response
+			enablePollout(clientFD);
+		}
+		catch (const std::exception &e)
+		{
+			std::cerr << e.what() << '\n';
+		}
 	}
-	catch (const std::exception &e)
+	else
 	{
-		std::cerr << e.what() << '\n';
+		Logger::log(INFO, "[ServerManager] Request not complete for client FD " + std::to_string(clientFD));
+		return;
+	}
+}
+
+void ServerManager::enablePollout(int clientFD)
+{
+	for (auto &pfd : _pollFDs)
+	{
+		if (pfd.fd == clientFD)
+		{
+			pfd.events |= POLLOUT;
+			return;
+		}
+	}
+}
+
+void ServerManager::disablePollout(int clientFD)
+{
+	for (auto &pfd : _pollFDs)
+	{
+		if (pfd.fd == clientFD)
+		{
+			pfd.events &= ~POLLOUT;
+			Logger::log(INFO, "[ServerManager] Disabled POLLOUT for client FD " + std::to_string(clientFD));
+			return;
+		}
 	}
 }
 
@@ -323,6 +386,45 @@ void ServerManager::checkTimeouts()
 			removeClient(clientFD);
 		}
 	}
+}
+
+/**
+ * @brief Check if the request is complete
+ * @param buffer The HTTP request buffer
+ * GET, HEAD does not have a body,
+ * for the rest check if the Content-Length header is present and if the body is complete
+ */
+
+bool ServerManager::isRequestComplete(const std::string &buffer)
+{
+
+	size_t headerEnd = buffer.find("\r\n\r\n");
+	if (headerEnd == std::string::npos)
+	{
+		return false;
+	}
+	if (buffer.find("GET") == 0 || buffer.find("HEAD") == 0)
+	{
+		return true;
+	}
+
+	size_t pos = buffer.find("Content-Length:");
+	size_t start = buffer.find(":", pos) + 1;
+	size_t end = buffer.find("\r\n", start);
+	if (end == std::string::npos)
+	{
+		return false;
+	}
+
+	std::string valueStr = buffer.substr(start, end - start);
+	int contentLength = std::stoi(valueStr);
+
+	size_t totalSize = headerEnd + 4 + contentLength;
+	if (buffer.size() >= totalSize)
+	{
+		return true;
+	}
+	return false;
 }
 
 void ServerManager::handleSigint(int sig)


### PR DESCRIPTION
fix #52 
    Improve `ServerManager (POLLIN, POLLOUT),` read-write in chunks
    This commit includes improvements for `ServerManager`:
    - reading the request as chunks, when the whole request is done, send it to `HTTPParser`...
    - sent the response as chunks, for a big response.
    
The response should be sent in when the socket in `POLLOUT` mode
`isRequestComplete()`: keep reading from the socket until is return true.