### PR TITLE
fix headers with port in scanner

### DIFF
--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -17,7 +17,7 @@ public:
 	std::string getBody() const;
 	static std::string headersToString(std::unordered_map<std::string, std::string>);
 	static std::string requestToString(const Request& request);
-	const std::string& getHost();
+	std::string& getHost() const;
 	Request(std::vector<Token>);
 	Request(const Request &);
 	~Request(void);

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -123,6 +123,12 @@ Request::Request(std::vector<Token> tokens)
 			std::size_t delimiter = header.find(':');
 			std::string header_name = header.substr(0, delimiter);
 			std::string header_value = header.substr(delimiter + 2, header.size() - 1);
+            if (header_name == "Host")
+            {
+                delimiter = header_value.find(':');
+                if (delimiter != std::string::npos)
+                    header_value = header_value.substr(0, delimiter);
+            }
 			headers.insert({header_name, header_value});
 		}
 		break;
@@ -144,7 +150,7 @@ Request::~Request(void)
 {
 }
 
-const std::string &Request::getHost()
+std::string &Request::getHost() const
 {
 	std::unordered_map<std::string, std::string> headers = getHeaders();
 	std::unordered_map<std::string, std::string>::iterator it = headers.find("Host");


### PR DESCRIPTION
- fix for https://github.com/julicaro31/Webserv/issues/85
- Request class trims port if it is found in host header