### PR TITLE
fixed cgihandler constructor exception not being caught

### DIFF
--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -478,10 +478,10 @@ void Response::handleCgiRequest()
 	std::string cgi_content;
 	std::string scriptPath = getFullPath(_root + _request.getUri());
 	Logger::log(INFO, "executing CGI script at " + scriptPath);
-	CgiHandler cgi(scriptPath, _request, method);
 
 	try
 	{
+        CgiHandler cgi(scriptPath, _request, method);
 		cgi_content = cgi.execute();
 	}
 	catch (timeout_exception &e)


### PR DESCRIPTION
- found that the constructor was not being called in a try block, which would create the scenario of some exceptions not being caught